### PR TITLE
Links to the Github project

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,3 +45,17 @@ heading_anchors: true
 
 # Color scheme currently only supports "dark", "light"/nil (default), or a custom scheme that you define
 color_scheme: "light"
+
+# Aux links for the upper right navigation
+aux_links:
+  "CloudAdoptionPatterns on GitHub":
+    - "//github.com/kgb1001001/cloudadoptionpatterns"
+
+# Footer "Edit this page on GitHub" link text
+gh_edit_link: true # show or hide edit this page link
+gh_edit_link_text: "Edit this page on GitHub."
+gh_edit_repository: "https://github.com/kgb1001001/cloudadoptionpatterns" # the github URL for your repo
+gh_edit_branch: "main" # the branch that your docs is served from
+# gh_edit_source: docs # the source that your files originate from
+gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
+


### PR DESCRIPTION
Just-the-docs shows links to the Github project and an 'edit on github' link... that's if you want to have that closer association or encouragement to collaborate.